### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Special thanks to all the contributors who have helped in this project:
 
 ## Star History
 
-<a href="https://star-history.com/#FQrabbit/SSTap-Rule&Date">
+<a href="https://star-history.dera.page/#FQrabbit/SSTap-Rule&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=FQrabbit/SSTap-Rule&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=FQrabbit/SSTap-Rule&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=FQrabbit/SSTap-Rule&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=FQrabbit/SSTap-Rule&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=FQrabbit/SSTap-Rule&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=FQrabbit/SSTap-Rule&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
README.md 中的 Star History 图表当前无法正常显示，原因是 GitHub 的星标接口限制导致数据无法获取。已更换为可正常工作的图表服务，保证项目页面的 Star History 信息能够正确展示。